### PR TITLE
Adding Javadocs to tests for the interactors, controllers, and presenters of use cases

### DIFF
--- a/test/controller/NotifyUserTourTest.java
+++ b/test/controller/NotifyUserTourTest.java
@@ -8,11 +8,37 @@ import use_case.notify_user_tour.NotifyInputData;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * The NotifyUserTourTest class contains JUnit tests for the NotifyController and associated
+ * components in the "notify_user_tour" package in interface_adapter.
+ * It focuses on testing the success scenario of the notification feature.
+ *
+ * The test case checks the functionality of the NotifyController by verifying that the input boundary
+ * object is correctly invoked and that the expected data is passed to it. The test specifically examines the
+ * successful notification scenario when the user's favorite artists are provided to the controller.
+ *
+ *  First, an input boundary object is created to simulate the interaction with the
+ *  notification use case. Define an object as an anonymous class implementing the interface, where the
+ *  execute method verifies that the provided favorite artist names match the expected ones.
+ *
+ *  Then, create a NotifyController instance with the previously defined success input boundary.
+ *  The controller can then be invoked by passing in a string containing the favorite artist names.
+ *
+ *  Finally, assert that the input boundary's execute method was called with the correct data.
+ *
+ */
 public class NotifyUserTourTest {
+
+    /**
+     * Test the success scenario of the NotifyController by providing a set of favorite artist names
+     * and ensuring that the input boundary's execute method is called with the correct data.
+     */
     @Test
     void successTest() {
-        // creating the input boundary object
+
         String favouriteArtistName = "Taylor Swift, Lizzy Mcalpine, Laufey, Niki, Nicki Minaj";
+
+        // creating the input boundary object
         NotifyInputBoundary successInteractor = new NotifyInputBoundary() {
 
             @Override

--- a/test/controller/UpcomingShowsTest.java
+++ b/test/controller/UpcomingShowsTest.java
@@ -6,11 +6,37 @@ import use_case.upcoming_shows.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+
+/**
+ * The UpcomingShowsTest class contains JUnit tests for the UpcomingController and associated
+ * components in the "controller" package. It focuses on testing the success scenarios of the upcoming shows feature.
+ *
+ * The test case checks the functionality of the UpcomingController by verifying that the controller
+ * correctly interacts with the input boundary object and triggers the upcoming shows use case successfully.
+ * The test creates an input boundary object, a success input interactor, and a controller to simulate a successful
+ * execution of the upcoming shows use case.
+ *
+ * First create an input boundary object (UpcomingInputBoundary) to simulate the interaction with the
+ * upcoming shows use case. The object is defined as an anonymous class implementing the interface, where the
+ * execute method verifies that the provided postal code matches the expected one.
+ *
+ * Then, create an UpcomingController instance with the previously defined success input boundary.
+ *
+ * Finally, invoke the controller by passing in the postal code.
+ *
+ */
 public class UpcomingShowsTest {
+
+    /**
+     * Test the success scenario of the UpcomingController by creating necessary input boundary
+     * and verifying that the controller executes the upcoming shows use case with the correct postal code.
+     */
     @Test
     void successTest() {
-        // creating the input boundary object
+
         String postalCode = "M1J3J9";
+
+        // creating the input boundary object
         UpcomingInputBoundary successInteractor = new UpcomingInputBoundary() {
 
             @Override
@@ -21,7 +47,7 @@ public class UpcomingShowsTest {
 
         };
 
-        // creating the interactor
+        // creating the controller
         UpcomingController controller = new UpcomingController(successInteractor);
 
         // invoking the controller by passing in the postal code

--- a/test/interactor/NotifyUserTourTest.java
+++ b/test/interactor/NotifyUserTourTest.java
@@ -9,7 +9,33 @@ import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * The NotifyUserTourTest class contains JUnit tests for the NotifyInteractor and associated
+ * components in the "interactor" package. It focuses on testing the success scenarios of the notification feature.
+ *
+ * The test case checks the functionality of the NotifyInteractor by verifying that the interactor
+ * correctly handles input data, interacts with the data access layer, and provides the expected output to the
+ * NotifyOutputBoundary. The test creates an input data object, a data access object, and a success
+ * output presenter to simulate a successful execution of the notification use case.
+ *
+ * First, create a NotifyInputData object representing the input data, such as a list of favorite artists and a
+ * InMemoryUserDataAccessObject as a mock data access object for the user's tour information.
+ *
+ * Then, create a success output presenter (NotifyOutputBoundary) to verify the correctness of the
+ * output data, including the tour information for each artist.
+ *
+ * Create a NotifyInteractor instance, providing it with the input data, data access object, and
+ * the success output presenter.
+ *
+ * Finally, invoke the interactor by passing in the input data.
+ *
+ */
 public class NotifyUserTourTest {
+
+    /**
+     * Test the success scenario of the NotifyInteractor by creating necessary input data, data access,
+     * and output presenter, and verifying that the interactor execution results in the expected output.
+     */
     @Test
     void successTest() {
         NotifyInputData inputData = new NotifyInputData("Laufey, Taylor Swift, Olivia Rodrigo, Niki, Lizzy Mcalpine");
@@ -19,7 +45,7 @@ public class NotifyUserTourTest {
         NotifyOutputBoundary successPresenter = new NotifyOutputBoundary() {
             @Override
             public void prepareSuccessView(NotifyOutputData user) {
-                // 2 things to check: the output data is correct, and the user has been created in the DAO.
+
                 LinkedHashMap<String, String> hasTourMap = new LinkedHashMap<>();
                 hasTourMap.put("Laufey", "has a tour");
                 hasTourMap.put("Taylor Swift", "has a tour");
@@ -36,7 +62,10 @@ public class NotifyUserTourTest {
             }
         };
 
+        // creating the interactor
         NotifyInputBoundary interactor = new NotifyInteractor(userRepository, successPresenter, new UserModelFactory());
+
+        // invoking the interactor by passing in the input data
         interactor.execute(inputData);
     }
 }

--- a/test/interactor/ShowConcertsTest.java
+++ b/test/interactor/ShowConcertsTest.java
@@ -6,8 +6,27 @@ import use_case.show_concerts.*;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
-
+/**
+ * The ShowConcertsTest class contains JUnit tests for the ShowConcertsInteractor and associated
+ * components in the "interactor" package. It focuses on testing the success scenarios of the show concerts feature.
+ *
+ * The test case checks the functionality of the ShowConcertsInteractor by verifying that the interactor
+ * correctly interacts with the output boundary and handles the show concerts use case successfully. The test
+ * creates a success output presenter to simulate a successful execution of the show concerts use case.
+ *
+ * First, create a success output presenter (ShowConcertsOutputBoundary) to verify the success scenario.
+ *
+ * Then, create a ShowConcertsInteractor instance, providing it with the success output presenter.
+ *
+ * Finally, invoke the interactor to execute the show concerts use case.
+ *
+ */
 public class ShowConcertsTest {
+
+    /**
+     * Test the success scenario of the ShowConcertsInteractor by creating a success output presenter
+     * and verifying that the interactor execution results in a successful show concerts use case.
+     */
     @Test
     void successTest() {
 

--- a/test/interactor/UpcomingShowsTest.java
+++ b/test/interactor/UpcomingShowsTest.java
@@ -10,8 +10,33 @@ import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * The UpcomingShowsTest class contains JUnit tests for the UpcomingInteractor and associated
+ * components in the "interactor" package. It focuses on testing the success scenarios of the upcoming shows feature.
+ *
+ * The test case checks the functionality of the UpcomingInteractor by verifying that the interactor
+ * correctly handles input data, interacts with the data access layer, and provides the expected output to the
+ * UpcomingOutputBoundary. The test creates an input data object, a data access object, and a success
+ * output presenter to simulate a successful execution of the upcoming shows use case.
+ *
+ * First, create an UpcomingInputData object representing the input data, such as a postal code as well as
+ * an InMemoryUserDataAccessObject as a mock data access object for the upcoming shows.
+ *
+ * Then, create a success output presenter (UpcomingOutputBoundary) to verify the correctness of the
+ * output data, including the concert details and URLs.
+ *
+ * Create an UpcomingInteractor instance, providing it with the input data, data access object, and
+ * the success output presenter.
+ *
+ * Finally, invoke the interactor by passing in the input data.</li>
+ *
+ */
 class UpcomingShowsTest {
 
+    /**
+     * Test the success scenario of the UpcomingInteractor by creating necessary input data, data access,
+     * and output presenter, and verifying that the interactor execution results in the expected output.
+     */
     @Test
     void successTest() {
         // creating the input data object
@@ -23,8 +48,6 @@ class UpcomingShowsTest {
         UpcomingOutputBoundary successPresenter = new UpcomingOutputBoundary() {
             @Override
             public void prepareSuccessView(UpcomingOutputData upcomingConcerts) {
-                // 2 things to check: the output data is correct, and the postal code has valid coordinates.
-
                 LinkedHashMap<String, String> outputConcerts = new LinkedHashMap<>();
                 outputConcerts.put("KESmas - Kes The Band Live in Concert", "https://www.ticketmaster.ca/kesmas-kes-the-band-live-in-toronto-ontario-12-21-2023/event/10005F6AD6584CEE");
                 outputConcerts.put("Big Wreck", "https://www.ticketmaster.ca/big-wreck-toronto-ontario-12-22-2023/event/10005F09E92D43C5");

--- a/test/presenter/NotifyUserTourTest.java
+++ b/test/presenter/NotifyUserTourTest.java
@@ -11,10 +11,35 @@ import use_case.notify_user_tour.NotifyOutputData;
 import java.util.LinkedHashMap;
 
 
+/**
+ * The NotifyUserTourTest class contains JUnit tests for the NotifyPresenter and associated
+ * components in the "presenter" package. It focuses on testing the success scenarios of the notification feature.
+ *
+ * The test case checks the functionality of the NotifyPresenter by verifying that the presenter prepares
+ * the success view correctly. It involves creating and initializing necessary view models and a ViewManagerModel
+ * instance to simulate the interaction between the presenter and the views.
+ *
+ * First, create a LinkedHashMap representing artists on tour, where each entry consists of an artist name
+ * and a corresponding tour status.
+ *
+ * Then, create a NotifyOutputData instance using the constructed artist data and create instances of necessary view
+ * models and a ViewManagerModel to represent the required components for the notification presentation.
+ *
+ * Create a NotifyPresenter instance, providing it with the created view models and the view manager model.
+ *
+ * Finally, invoke the presenter to prepare the success view, passing in the NotifyOutputData
+ *
+ */
 public class NotifyUserTourTest {
+
+    /**
+     * Test the success scenario of the NotifyPresenter by creating necessary data and view models,
+     * and verifying that the presenter prepares the success view without errors.
+     */
     @Test
     void successTest() {
 
+        // creating the expected output hash map from the notify user tour use case
         LinkedHashMap<String, String> artistsOnTour = new LinkedHashMap<>();
         artistsOnTour.put("Laufey", "has a tour");
         artistsOnTour.put("Taylor Swift", "has a tour");
@@ -24,6 +49,7 @@ public class NotifyUserTourTest {
 
         NotifyOutputData notifyOutputData = new NotifyOutputData(artistsOnTour);
 
+        // creating the required view models to pass into the presenter
         NotifyViewModel notifyViewModel = new NotifyViewModel();
 
         ArtistViewModel artistViewModel = new ArtistViewModel();

--- a/test/presenter/ShowConcertsTest.java
+++ b/test/presenter/ShowConcertsTest.java
@@ -7,10 +7,33 @@ import interface_adapter.show_concerts.ShowConcertsViewModel;
 import org.junit.jupiter.api.Test;
 
 
+/**
+ * The ShowConcertsTest class contains JUnit tests for the ShowConcertsPresenter and associated
+ * components in the application. It focuses on testing the success scenarios of the concert presentation feature.
+ *
+ * The test case checks the functionality of the ShowConcertsPresenter by verifying that the presenter
+ * prepares the success view correctly. It involves creating and initializing necessary view models and a
+ * ViewManagerModel instance to simulate the interaction between the presenter and the views.
+ *
+ * First, create an instance of the necessary view models and a ViewManagerModel to represent the required
+ * components for concert presentation.
+ *
+ * Then, create a ShowConcertsPresenter instance, providing it with the created view models and
+ * the view manager model.
+ *
+ * Finally, invoke the presenter to prepare the success view.
+ *
+ */
 public class ShowConcertsTest {
+
+    /**
+     * Test the success scenario of the ShowConcertsPresenter by creating necessary view models and
+     * a view manager model, and verifying that the presenter prepares the success view without errors.
+     */
     @Test
     void successTest() {
 
+        // creating the required view models to pass into the presenter
         ShowConcertsViewModel showConcertsViewModel = new ShowConcertsViewModel();
 
         NotifyViewModel notifyViewModel = new NotifyViewModel();

--- a/test/presenter/UpcomingShowsTest.java
+++ b/test/presenter/UpcomingShowsTest.java
@@ -11,7 +11,31 @@ import use_case.upcoming_shows.UpcomingOutputData;
 
 import java.util.LinkedHashMap;
 
+/**
+ * The UpcomingShowsTest class contains JUnit tests for the UpcomingPresenter and associated
+ * components in the "presenter" package. It focuses on testing the success scenarios of presenting upcoming shows.
+ *
+ * <p>The test case checks the functionality of the UpcomingPresenter by verifying that the presenter
+ * correctly prepares the view model for upcoming shows. The test creates a mock output data object representing
+ * upcoming concerts, view models, and a presenter to simulate a successful presentation of upcoming shows.</p>
+ *
+ * First, create a LinkedHashMap representing upcoming concerts with their names and ticket URLs and create an
+ * UpcomingOutputData object with the upcoming concerts data.
+ *
+ * Then create view models (UpcomingViewModel) and (ShowConcertsViewModel) to hold the presented data and create a
+ * ViewManagerModel to manage the views.
+ *
+ * Create an UpcomingPresenter instance, providing it with the view manager and view models.
+ *
+ * Finally invoke the presenter by passing in the upcoming output data.
+ *
+ */
 public class UpcomingShowsTest {
+
+    /**
+     * Test the success scenario of the UpcomingController by creating necessary input boundary
+     * and verifying that the controller executes the upcoming shows use case with the correct postal code.
+     */
     @Test
     void successTest() {
 


### PR DESCRIPTION
Adding Javadocs to tests for the interactors, controllers, and presenters of the Notify User Tour, Upcoming Shows, and Show Concerts use cases